### PR TITLE
feat: add deprecated-at-end flag and multiline magic comment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Go CLI tool that automatically sorts TypeScript object literals marked with sp
 - 🔍 Dry-run mode by default (see changes before applying)
 - ✅ Check mode for CI/CD pipelines
 - 📐 Optional `with-new-line` formatting for extra spacing
+- 🚨 Optional `deprecated-at-end` to move `@deprecated` properties to the bottom
 
 ## Installation
 
@@ -108,6 +109,75 @@ const config = {
   beta: "second",
 
   zebra: "last",
+};
+```
+
+### Advanced: deprecated-at-end option
+
+Move properties with `@deprecated` annotations to the bottom of the object:
+
+```typescript
+const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  activeFeature: true,
+  /** @deprecated Use newApiUrl instead */
+  oldApiUrl: "https://old.example.com",
+  newApiUrl: "https://api.example.com",
+  legacyMode: true, // @deprecated Will be removed in v2.0
+};
+```
+
+After sorting:
+
+```typescript
+const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  activeFeature: true,
+  newApiUrl: "https://api.example.com",
+  legacyMode: true, // @deprecated Will be removed in v2.0
+  /** @deprecated Use newApiUrl instead */
+  oldApiUrl: "https://old.example.com",
+};
+```
+
+You can also combine it with `with-new-line`:
+
+```typescript
+const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end with-new-line **/
+  alpha: "first",
+
+  beta: "second",
+
+  /** @deprecated */
+  oldValue: "deprecated",
+};
+```
+
+### Multiline magic comments
+
+For better readability, you can split the magic comment across multiple lines:
+
+```typescript
+const config = {
+  /**
+   * tree-sorter-ts: keep-sorted
+   *   with-new-line
+   *   deprecated-at-end
+   */
+  activeFeature: true,
+  beta: "second",
+  /** @deprecated */
+  oldFeature: false,
+};
+
+// Also works without asterisks on each line:
+const config2 = {
+  /** tree-sorter-ts: keep-sorted
+      deprecated-at-end
+      with-new-line **/
+  gamma: true,
+  alpha: "first",
 };
 ```
 

--- a/internal/processor/deprecated_test.go
+++ b/internal/processor/deprecated_test.go
@@ -1,0 +1,378 @@
+package processor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSortConfigDeprecated(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    SortConfig
+	}{
+		{
+			name:    "default_no_deprecated",
+			comment: `/** tree-sorter-ts: keep-sorted */`,
+			want:    SortConfig{WithNewLine: false, DeprecatedAtEnd: false},
+		},
+		{
+			name:    "with_deprecated_at_end",
+			comment: `/** tree-sorter-ts: keep-sorted deprecated-at-end */`,
+			want:    SortConfig{WithNewLine: false, DeprecatedAtEnd: true},
+		},
+		{
+			name:    "with_deprecated_and_newline",
+			comment: `/** tree-sorter-ts: keep-sorted deprecated-at-end with-new-line */`,
+			want:    SortConfig{WithNewLine: true, DeprecatedAtEnd: true},
+		},
+		{
+			name:    "with_newline_and_deprecated",
+			comment: `/** tree-sorter-ts: keep-sorted with-new-line deprecated-at-end */`,
+			want:    SortConfig{WithNewLine: true, DeprecatedAtEnd: true},
+		},
+		{
+			name:    "deprecated_extra_spaces",
+			comment: `/**  tree-sorter-ts:  keep-sorted   deprecated-at-end  **/`,
+			want:    SortConfig{WithNewLine: false, DeprecatedAtEnd: true},
+		},
+		{
+			name: "deprecated_multiline_comment",
+			comment: `/**
+			 * tree-sorter-ts: keep-sorted deprecated-at-end
+			 */`,
+			want: SortConfig{WithNewLine: false, DeprecatedAtEnd: true},
+		},
+		{
+			name:    "single_star_comment_deprecated",
+			comment: `/* tree-sorter-ts: keep-sorted deprecated-at-end */`,
+			want:    SortConfig{WithNewLine: false, DeprecatedAtEnd: true},
+		},
+		{
+			name: "multiline_flags_on_separate_lines",
+			comment: `/**
+			 * tree-sorter-ts: keep-sorted
+			 * deprecated-at-end
+			 * with-new-line
+			 */`,
+			want: SortConfig{WithNewLine: true, DeprecatedAtEnd: true},
+		},
+		{
+			name: "multiline_flags_with_extra_asterisks",
+			comment: `/**
+			 * tree-sorter-ts: keep-sorted
+			 *   with-new-line
+			 *   deprecated-at-end
+			 */`,
+			want: SortConfig{WithNewLine: true, DeprecatedAtEnd: true},
+		},
+		{
+			name: "multiline_mixed_same_line",
+			comment: `/**
+			 * tree-sorter-ts: keep-sorted
+			 * deprecated-at-end with-new-line
+			 */`,
+			want: SortConfig{WithNewLine: true, DeprecatedAtEnd: true},
+		},
+		{
+			name: "multiline_no_asterisks",
+			comment: `/** tree-sorter-ts: keep-sorted
+			    deprecated-at-end
+			    with-new-line **/`,
+			want: SortConfig{WithNewLine: true, DeprecatedAtEnd: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSortConfig([]byte(tt.comment))
+			if got.WithNewLine != tt.want.WithNewLine {
+				t.Errorf("parseSortConfig() WithNewLine = %v, want %v", got.WithNewLine, tt.want.WithNewLine)
+			}
+			if got.DeprecatedAtEnd != tt.want.DeprecatedAtEnd {
+				t.Errorf("parseSortConfig() DeprecatedAtEnd = %v, want %v", got.DeprecatedAtEnd, tt.want.DeprecatedAtEnd)
+			}
+		})
+	}
+}
+
+func TestDeprecatedAtEnd(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		wantSorted   string
+		wantNeedSort int
+	}{
+		{
+			name: "deprecated_properties_at_end",
+			content: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  gamma: true,
+  /** @deprecated Use newApi instead */
+  oldApi: "old",
+  alpha: "first",
+  newApi: "new",
+  /** @deprecated */
+  beta: false,
+};`,
+			wantSorted: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  alpha: "first",
+  gamma: true,
+  newApi: "new",
+  /** @deprecated */
+  beta: false,
+  /** @deprecated Use newApi instead */
+  oldApi: "old",
+};`,
+			wantNeedSort: 1,
+		},
+		{
+			name: "deprecated_in_inline_comment",
+			content: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  gamma: 123,
+  oldSetting: "old", // @deprecated use newSetting
+  delta: true,
+  epsilon: "test",
+  newSetting: "new",
+};`,
+			wantSorted: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  delta: true,
+  epsilon: "test",
+  gamma: 123,
+  newSetting: "new",
+  oldSetting: "old", // @deprecated use newSetting
+};`,
+			wantNeedSort: 1,
+		},
+		{
+			name: "mixed_deprecated_annotations",
+			content: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  active: true,
+  /** @deprecated Will be removed in v2.0 */
+  oldFeature: false,
+  beta: "test",
+  /** This is not deprecated */
+  alpha: "first",
+  legacyMode: true, // @deprecated
+  newFeature: true,
+};`,
+			wantSorted: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  active: true,
+  /** This is not deprecated */
+  alpha: "first",
+  beta: "test",
+  newFeature: true,
+  legacyMode: true, // @deprecated
+  /** @deprecated Will be removed in v2.0 */
+  oldFeature: false,
+};`,
+			wantNeedSort: 1,
+		},
+		{
+			name: "no_deprecated_properties",
+			content: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  zebra: "last",
+  alpha: "first",
+  beta: "second",
+};`,
+			wantSorted: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  alpha: "first",
+  beta: "second",
+  zebra: "last",
+};`,
+			wantNeedSort: 1,
+		},
+		{
+			name: "deprecated_already_sorted",
+			content: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  active: true,
+  beta: "test",
+  /** @deprecated */
+  oldApi: "old",
+  /** @deprecated */
+  oldFeature: false,
+};`,
+			wantSorted:   "", // No change
+			wantNeedSort: 0,
+		},
+		{
+			name: "deprecated_with_newline",
+			content: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end with-new-line **/
+  gamma: true,
+  /** @deprecated */
+  beta: false,
+  alpha: "first",
+  newApi: "new",
+  /** @deprecated Use newApi instead */
+  oldApi: "old",
+};`,
+			wantSorted: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end with-new-line **/
+  alpha: "first",
+
+  gamma: true,
+
+  newApi: "new",
+
+  /** @deprecated */
+  beta: false,
+
+  /** @deprecated Use newApi instead */
+  oldApi: "old",
+};`,
+			wantNeedSort: 1,
+		},
+		{
+			name: "deprecated_with_trailing_comma",
+			content: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  gamma: true,
+  /** @deprecated */
+  oldApi: "old",
+  alpha: "first",
+};`,
+			wantSorted: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  alpha: "first",
+  gamma: true,
+  /** @deprecated */
+  oldApi: "old",
+};`,
+			wantNeedSort: 1,
+		},
+		{
+			name: "all_properties_deprecated",
+			content: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  /** @deprecated */
+  gamma: true,
+  /** @deprecated Use newApi instead */
+  beta: "old",
+  /** @deprecated */
+  alpha: "first",
+};`,
+			wantSorted: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  /** @deprecated */
+  alpha: "first",
+  /** @deprecated Use newApi instead */
+  beta: "old",
+  /** @deprecated */
+  gamma: true,
+};`,
+			wantNeedSort: 1,
+		},
+		{
+			name: "deprecated_without_flag",
+			content: `const config = {
+  /** tree-sorter-ts: keep-sorted **/
+  gamma: true,
+  /** @deprecated Use newApi instead */
+  oldApi: "old",
+  alpha: "first",
+  newApi: "new",
+};`,
+			wantSorted: `const config = {
+  /** tree-sorter-ts: keep-sorted **/
+  alpha: "first",
+  gamma: true,
+  newApi: "new",
+  /** @deprecated Use newApi instead */
+  oldApi: "old",
+};`,
+			wantNeedSort: 1,
+		},
+		{
+			name: "deprecated_multiline_comment",
+			content: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  gamma: true,
+  /** 
+   * @deprecated This is a multiline
+   * deprecated comment that should
+   * still be detected
+   */
+  oldApi: "old",
+  alpha: "first",
+};`,
+			wantSorted: `const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  alpha: "first",
+  gamma: true,
+  /** 
+   * @deprecated This is a multiline
+   * deprecated comment that should
+   * still be detected
+   */
+  oldApi: "old",
+};`,
+			wantNeedSort: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test detection
+			result := ProcessResult{}
+			root, contentBytes, err := parseTypeScript(tt.content)
+			if err != nil {
+				t.Fatalf("Failed to parse: %v", err)
+			}
+
+			objects := findObjectsWithMagicCommentsAST(root, contentBytes)
+			result.ObjectsFound = len(objects)
+
+			// Count how many need sorting
+			for _, obj := range objects {
+				_, needsSort := sortObjectAST(obj, contentBytes)
+				if needsSort {
+					result.ObjectsNeedSort++
+				}
+			}
+
+			if result.ObjectsNeedSort != tt.wantNeedSort {
+				t.Errorf("ObjectsNeedSort = %d, want %d", result.ObjectsNeedSort, tt.wantNeedSort)
+			}
+
+			// Test mutation if sorting is needed
+			if tt.wantSorted != "" {
+				// Apply sorts
+				newContent := make([]byte, len(contentBytes))
+				copy(newContent, contentBytes)
+
+				// Sort from end to beginning
+				for i := len(objects) - 1; i >= 0; i-- {
+					sortedContent, needsSort := sortObjectAST(objects[i], newContent)
+					if needsSort {
+						start := objects[i].object.StartByte()
+						end := objects[i].object.EndByte()
+
+						before := newContent[:start]
+						after := newContent[end:]
+						newContent = append(append(before, sortedContent...), after...)
+					}
+				}
+
+				got := string(newContent)
+				want := tt.wantSorted
+
+				// Normalize whitespace for comparison
+				got = strings.TrimSpace(got)
+				want = strings.TrimSpace(want)
+
+				if got != want {
+					t.Errorf("Sorted output mismatch.\nGot:\n%s\n\nWant:\n%s", got, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/processor/simple.go
+++ b/internal/processor/simple.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	magicCommentRegex = regexp.MustCompile(`(?s)/\*\*?\s*tree-sorter-ts:\s*keep-sorted\s*([^*]*)\*+/`)
+	magicCommentRegex = regexp.MustCompile(`(?s)/\*\*?.*?tree-sorter-ts:\s*keep-sorted\b.*?\*/`)
 
 	// Parser pool to avoid recreating parsers
 	parserPool = sync.Pool{

--- a/testdata/fixtures/deprecated-at-end.ts
+++ b/testdata/fixtures/deprecated-at-end.ts
@@ -1,0 +1,21 @@
+const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  activeFeature: true,
+  beta: "test",
+  /** @deprecated Use newApiUrl instead */
+  oldApiUrl: "https://old.example.com",
+  zebra: false,
+  /** @deprecated Will be removed in v2.0 */  
+  legacyMode: true,
+  alpha: "first",
+  newApiUrl: "https://api.example.com", // replaces oldApiUrl
+};
+
+const anotherConfig = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
+  gamma: 123,
+  oldSetting: "old", // @deprecated use newSetting
+  delta: true,
+  epsilon: "test",
+  newSetting: "new",
+};

--- a/testdata/fixtures/deprecated-with-new-line.ts
+++ b/testdata/fixtures/deprecated-with-new-line.ts
@@ -1,0 +1,14 @@
+const config = {
+  /** tree-sorter-ts: keep-sorted deprecated-at-end with-new-line **/
+  alpha: "first",
+
+  gamma: true,
+
+  newApi: "new",
+
+  /** @deprecated */
+  beta: false,
+
+  /** @deprecated Use newApi instead */
+  oldApi: "old",
+};

--- a/testdata/fixtures/multiline-magic-comment.ts
+++ b/testdata/fixtures/multiline-magic-comment.ts
@@ -1,0 +1,56 @@
+const config1 = {
+  /** tree-sorter-ts: keep-sorted
+      deprecated-at-end with-new-line **/
+  alpha: "first",
+
+  beta: "second",
+
+  gamma: true,
+
+  /** @deprecated */
+  oldApi: "old",
+},
+}const config2 = {
+  /** 
+   * tree-sorter-ts: keep-sorted
+   * deprecated-at-end 
+   * with-new-line 
+   **/
+  alpha: "first",
+
+  beta: "second",
+
+  zebra: "last",
+
+  /** @deprecated */
+  oldFeature: false,
+},
+}const config3 = {
+  /**
+   * tree-sorter-ts: keep-sorted
+   * deprecated-at-end with-new-line
+   */
+  alpha: "first",
+
+  charlie: "third",
+
+  delta: true,
+
+  /** @deprecated Use newValue */
+  oldValue: "old",
+},
+}const config4 = {
+  /**
+   * tree-sorter-ts: keep-sorted
+   *   with-new-line
+   *   deprecated-at-end
+   */
+  alpha: "first",
+
+  beta: "second",
+
+  zebra: "last",
+
+  /** @deprecated */
+  oldItem: "old",
+};


### PR DESCRIPTION
## Summary
- Added `deprecated-at-end` flag to automatically move `@deprecated` properties to the bottom of objects
- Enhanced magic comment parser to support multiline formats for better readability
- Comprehensive test coverage for both features

## Motivation
As codebases evolve, deprecated properties accumulate but need to remain for backward compatibility. This feature helps maintain clean, organized code by automatically grouping deprecated properties at the bottom of objects, making it easier to identify what's current vs. what's being phased out.

Additionally, as we add more configuration flags, single-line magic comments become hard to read. Multiline support improves maintainability.

## Changes

### 1. deprecated-at-end flag
- Properties with `@deprecated` annotations (in block or inline comments) are moved to the bottom
- Both groups (non-deprecated and deprecated) maintain alphabetical order
- Works seamlessly with existing flags like `with-new-line`

### 2. Multiline magic comment support
Multiple formats are now supported:
```typescript
// Original single line
/** tree-sorter-ts: keep-sorted deprecated-at-end with-new-line **/

// Multiline with asterisks
/**
 * tree-sorter-ts: keep-sorted
 *   with-new-line
 *   deprecated-at-end
 */

// Multiline without asterisks
/** tree-sorter-ts: keep-sorted
    deprecated-at-end
    with-new-line **/
```

### Implementation details
- Updated `SortConfig` struct with `DeprecatedAtEnd` boolean field
- Enhanced `parseSortConfig` to strip asterisks from multiline comments
- Modified regex pattern from `/\*\*?\s*tree-sorter-ts:\s*keep-sorted\b.*?\*/` to `/\*\*?.*?tree-sorter-ts:\s*keep-sorted\b.*?\*/`
- Added `isDeprecated` field to `astProperty` struct
- Updated sorting logic to group by deprecation status first, then alphabetically

## Test plan
- [x] Added comprehensive test suite in `deprecated_test.go`
- [x] Tests cover parsing multiline comments in various formats
- [x] Tests verify correct sorting with deprecated properties
- [x] Tests confirm compatibility with existing flags
- [x] All existing tests continue to pass
- [x] Manual testing with real TypeScript files

## Examples

### Before
```typescript
const config = {
  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
  activeFeature: true,
  /** @deprecated Use newApiUrl instead */
  oldApiUrl: "https://old.example.com",
  newApiUrl: "https://api.example.com",
  legacyMode: true, // @deprecated Will be removed in v2.0
};
```

### After
```typescript
const config = {
  /** tree-sorter-ts: keep-sorted deprecated-at-end **/
  activeFeature: true,
  newApiUrl: "https://api.example.com",
  legacyMode: true, // @deprecated Will be removed in v2.0
  /** @deprecated Use newApiUrl instead */
  oldApiUrl: "https://old.example.com",
};
```

🤖 Generated with [Claude Code](https://claude.ai/code)